### PR TITLE
Ajout de php-curl dans les modules PHP nécessaires

### DIFF
--- a/pages/03.installation-et-mise-a-jour/01.installation/default.md
+++ b/pages/03.installation-et-mise-a-jour/01.installation/default.md
@@ -33,6 +33,7 @@ GRR, fonction sur un serveur web avec PHP et MySQL. Nous de détaillerons pas l'
 * php-mysqlnd
 * php-xml
 * php-intl `(Obligatoire depuis la version GRR 4.1.0)`
+* php-curl `(Nécessaire seulement si on utilise l'authentification SSO)`
 
 ## 2.2 - Poste client
 


### PR DESCRIPTION
Ajout de php-curl dans les modules PHP nécessaires dans le cas où on veut utiliser l'authentification SSO.